### PR TITLE
[RFC] Failing case of a corrupted JS API Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ matrix:
         - set +e
     - if: commit_message !~ /Bump version/
       stage: main
+      name: Auto generated js client tests
+      script:
+        - docker run --rm -v `pwd`:/local --user `id -u`:`id -g` openapitools/openapi-generator-cli generate --input-spec=/local/spec/openapi.yaml --generator-name=javascript --output=/local/js-client
+        - npm --prefix js-client install
+        - npm --prefix js-client test
+    - if: commit_message !~ /Bump version/
+      stage: main
       name: Docker build smoke test
       before_install:
         - docker load -i $HOME/docker/images.tar || true

--- a/server/athenian/api/openapi/openapi.yaml
+++ b/server/athenian/api/openapi/openapi.yaml
@@ -1314,9 +1314,7 @@ components:
         values:
           description: Calculated metric values in the same order as `metrics`.
           items:
-# {% if False %}
-            allOf:
-# {% else %}{{ "\n" }}            oneOf:{% endif %}
+            oneOf:
             - type: integer
             - format: float
               type: number
@@ -1327,9 +1325,7 @@ components:
             It is optional because there can be exact metrics like "count open PRs
             per month".
           items:
-# {% if False %}
-            allOf:
-# {% else %}{{ "\n" }}            oneOf:{% endif %}
+            oneOf:
             - type: integer
             - format: float
               type: number
@@ -1340,9 +1336,7 @@ components:
             It is optional because there can be exact metrics like "count open PRs
             per month".
           items:
-# {% if False %}
-            allOf:
-# {% else %}{{ "\n" }}            oneOf:{% endif %}
+            oneOf:
             - type: integer
             - format: float
               type: number


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-api/pull/139

If c27e1c31c808002090466bcd1cec88d5158b4aa8 is reverted, the `oneOff` issue ([[1]](https://github.com/OpenAPITools/openapi-generator/issues/912),[[2]](https://github.com/OpenAPITools/openapi-generator/issues/15),[[3]](https://github.com/OpenAPITools/openapi-generator/issues/634)) will be reproducible again, and this test will rise a red flag in Travis [like this one](https://travis-ci.com/dpordomingo/athenian-api/jobs/293797859#L488).